### PR TITLE
Add streamDownloads option

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -11,7 +11,11 @@ import {
 import { routes } from '../lib/routes.js';
 import DropboxAuth from './auth.js';
 import { baseApiUrl, httpHeaderSafeJson } from './utils.js';
-import { parseDownloadResponse, parseResponse } from './response.js';
+import {
+  parseDownloadResponse,
+  parseDownloadResponseAsStream,
+  parseResponse
+} from './response.js';
 
 const b64 = typeof btoa === 'undefined'
   ? (str) => Buffer.from(str).toString('base64')
@@ -61,6 +65,7 @@ export default class Dropbox {
     this.selectUser = options.selectUser;
     this.selectAdmin = options.selectAdmin;
     this.pathRoot = options.pathRoot;
+    this.streamDownloads = options.streamDownloads;
 
     this.domain = options.domain || this.auth.domain;
     this.domainDelimiter = options.domainDelimiter || this.auth.domainDelimiter;
@@ -127,7 +132,13 @@ export default class Dropbox {
         baseApiUrl(host, this.domain, this.domainDelimiter) + path,
         fetchOptions,
       ))
-      .then((res) => parseDownloadResponse(res));
+      .then((res) => {
+        if (this.streamDownloads) {
+          return parseDownloadResponseAsStream(res);
+        } else {
+          return parseDownloadResponse(res);
+        }
+      })
   }
 
   uploadRequest(path, args, auth, host) {

--- a/src/response.js
+++ b/src/response.js
@@ -62,3 +62,12 @@ export function parseDownloadResponse(res) {
     return new DropboxResponse(res.status, res.headers, result);
   });
 }
+
+export function parseDownloadResponseAsStream(res) {
+  if (!res.ok) {
+    return throwAsError(res);
+  }
+  const result = JSON.parse(res.headers.get('dropbox-api-result'));
+  result.fileStream = res.body;
+  return new DropboxResponse(res.status, res.headers, result);
+}

--- a/test/integration/user.js
+++ b/test/integration/user.js
@@ -124,6 +124,33 @@ for (const appType in appInfo) {
         });
       });
     });
+
+    describe(`User ${appType} (streamDownloads: true)`, () => {
+      let dbxAuth;
+      let dbx;
+
+      beforeEach(() => {
+        dbxAuth = new DropboxAuth(appInfo[appType]);
+        dbx = new Dropbox({ auth: dbxAuth, streamDownloads: true });
+      });
+
+      describe('download', () => {
+        it('download request is successful', (done) => {
+          dbx.sharingGetSharedLinkFile({ url: process.env.DROPBOX_SHARED_LINK })
+            .then((resp) => {
+              chai.assert.instanceOf(resp, DropboxResponse);
+              chai.assert.equal(resp.status, 200, resp.result);
+              chai.assert.isObject(resp.result);
+
+              chai.assert.isString(resp.result.name);
+              chai.assert.isDefined(resp.result.fileStream);
+
+              done();
+            })
+            .catch(done);
+        });
+      });
+    });
   }
 }
 

--- a/test/unit/response.js
+++ b/test/unit/response.js
@@ -6,6 +6,7 @@ import {
   DropboxResponse,
   parseResponse,
   parseDownloadResponse,
+  parseDownloadResponseAsStream,
 } from '../../src/response.js';
 import { DropboxResponseError } from '../../src/error.js';
 
@@ -73,6 +74,31 @@ describe('DropboxResponse', () => {
         };
         const response = new Response(undefined, init);
         chai.assert.isRejected(parseDownloadResponse(response), DropboxResponseError);
+      }
+    });
+  });
+
+  describe('parseDownloadResponseAsStream', () => {
+    it('correctly parses the response', () => {
+      const init = {
+        status: 200,
+        headers: {
+          'dropbox-api-result': httpHeaderSafeJson({ name: 'test.txt' }),
+        },
+      };
+      const response = new Response(undefined, init);
+      const dropboxResponse = parseDownloadResponseAsStream(response);
+      chai.assert.hasAllKeys(dropboxResponse.result, ['name', 'fileStream']);
+    });
+
+    it('throws an error when not a 200 status code', () => {
+      const statusArray = [300, 400, 500];
+      for (const status of statusArray) {
+        const init = {
+          status,
+        };
+        const response = new Response(undefined, init);
+        chai.assert.isRejected(parseDownloadResponseAsStream(response), DropboxResponseError);
       }
     });
   });


### PR DESCRIPTION
When this flag is turned on, calls to content-download endpoints return the file stream in result.fileStream rather than consuming it and returning the file contents in result.fileBinary.

This is for overleaf/internal#9880. I plan to also make an upstream PR if that works for us.